### PR TITLE
Support Union type

### DIFF
--- a/serious/__init__.py
+++ b/serious/__init__.py
@@ -20,4 +20,4 @@ from .json import JsonModel
 from .types import Timestamp, Email, FrozenList, FrozenDict
 from .validation import validate
 
-__version__ = '1.2.1'
+__version__ = '1.2.2'

--- a/serious/errors.py
+++ b/serious/errors.py
@@ -21,7 +21,6 @@ __all__ = [
     'ModelError',
     'FieldMissingSerializer',
     'ModelContainsAny',
-    'ModelContainsUnion',
     'MutableTypesInModel',
     'ValidationError',
 ]
@@ -156,14 +155,6 @@ class ModelContainsAny(ModelError):
                 f'Provide a type annotation or pass `allow_any=True` to the serializer. '
                 f'This may also be an ambiguous ``Generic`` definitions like `x: list`, `x: List` '
                 f'which are resolved as `List[Any]`. ')
-
-
-class ModelContainsUnion(ModelError):
-
-    @property
-    def message(self):
-        return (f'{class_path(self.cls)} contains fields annotated as Union. '
-                f'Union types are not supported by serious.')
 
 
 class MutableTypesInModel(ModelError):

--- a/serious/serialization/model.py
+++ b/serious/serialization/model.py
@@ -11,7 +11,7 @@ from typing import Generic, Iterable, Type, Dict, Any, Union, Mapping, Optional,
 
 from serious.checks import check_is_instance
 from serious.descriptors import scan_types, TypeDescriptor
-from serious.errors import ModelContainsAny, ModelContainsUnion, MissingField, UnexpectedItem, ValidationError, \
+from serious.errors import ModelContainsAny, MissingField, UnexpectedItem, ValidationError, \
     LoadError, DumpError, FieldMissingSerializer
 from serious.utils import Dataclass
 from serious.validation import validate
@@ -69,8 +69,6 @@ class SeriousModel(Generic[T]):
         all_types = scan_types(descriptor)
         if not allow_any and Any in all_types:
             raise ModelContainsAny(descriptor.cls)
-        if Union in all_types:
-            raise ModelContainsUnion(descriptor.cls)
         if ensure_frozen:
             check_immutable(descriptor, all_types, ensure_frozen)
         self.descriptor = descriptor

--- a/tests/test_union.py
+++ b/tests/test_union.py
@@ -1,21 +1,33 @@
 from dataclasses import dataclass
+from dataclasses import dataclass
 from typing import Union
 
-import pytest
-
-from serious import DictModel, ModelError
-from serious.errors import ModelContainsUnion
+from serious import JsonModel
 
 
-@dataclass
-class Something:
-    value: Union[str, int]
+@dataclass(frozen=True)
+class DataWithUnion:
+    something: Union[str, int]
 
 
-def test_union():
-    with pytest.raises(ModelContainsUnion):
-        DictModel(Something)
+class TestEnum:
+    def setup(self):
+        self.model = JsonModel(DataWithUnion)
 
+    def test_load(self):
+        union = DataWithUnion('test')
+        union_json = '{"something": {"__type__": "str", "__value__": "test"}}'
+        assert self.model.load(union_json) == union
 
-def test_model_contains_union_hierarchy():
-    assert issubclass(ModelContainsUnion, ModelError)
+        int_union = DataWithUnion(69)
+        int_union_json = '{"something": {"__type__": "int", "__value__": 69}}'
+        assert self.model.load(int_union_json) == int_union
+
+    def test_dump(self):
+        union = DataWithUnion('test')
+        union_json = '{"something": {"__type__": "str", "__value__": "test"}}'
+        assert self.model.dump(union) == union_json
+
+        int_union = DataWithUnion(-1)
+        int_union_json = '{"something": {"__type__": "int", "__value__": -1}}'
+        assert self.model.dump(int_union) == int_union_json


### PR DESCRIPTION
A JSON with format below will be created for Union types:

```python
@dataclass
class Everything:
    everywhere: Union[str, int, float]

Everything(everywhere="test!")
# {"everywhere": {"__type__": "str", "__value__": "test!"}}
```